### PR TITLE
Add `**kwargs` to `draw_themed_line`

### DIFF
--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -300,13 +300,16 @@ def get_interpolated_colors(color1, color2, color3, weights, colorspace="lab"):
     return np.minimum(rgb_colors, 1)
 
 
-def draw_themed_line(y, ax, orientation="horizontal"):
+def draw_themed_line(y, ax, orientation="horizontal", **kwargs):
     """Draw a horizontal line using the theme settings
 
     Args:
         y (float): Position of line in data coordinates
         ax (Axes): Matplotlib Axes on which line is drawn
-
+        orientation (str, optional): Orientation of line. Options are
+            ``"horizontal"`` or ``"vertical"``.
+        **kwargs: Additional keyword arguments passed to ``ax.axhline`` or
+            ``ax.axvline``, which can be used to override the theme settings.
     """
 
     # Note to future developers: feel free to add plenty more optional
@@ -320,6 +323,7 @@ def draw_themed_line(y, ax, orientation="horizontal"):
         zorder=0,
         linewidth=rcParams["ytick.major.width"],
     )
+    themed_line_options.update(kwargs)
 
     if orientation == "horizontal":
         ax.axhline(y, **themed_line_options)

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -217,9 +217,6 @@ class SBSPlotter(BSPlotter):
             style (:obj:`list`, :obj:`str`, or :obj:`dict`): Any matplotlib
                 style specifications, to be composed on top of Sumo base
                 style.
-                no_base_style (:obj:`bool`, optional): Prevent use of sumo base
-                style. This can make alternative styles behave more
-                predictably.
             no_base_style (:obj:`bool`, optional): Prevent use of sumo base
                 style. This can make alternative styles behave more
                 predictably.


### PR DESCRIPTION
Hi @utf and @ajjackson!
This is a tiny update to allow the user to pass `kwargs` to `draw_themed_line`. The main reason is so that we can control `zorder` when importing and using this function, if the band plot is e.g. actually a colourmap, in which case the default `zorder=0` hides the zero line, but bumping it up shows it. 
This is because I'm using `sumo` to add co - DOS plot functionality (like `sumo-bandplot`) to the unfolded bandstructure plotting in [`easyunfold`](https://smtg-ucl.github.io/easyunfold/), so using some of these useful functions! 🙌

Work in progress, but like this:
![image](https://github.com/SMTG-UCL/sumo/assets/51478689/fb9ace3d-51d7-4578-882a-4ff534939bdd)
