### PR TITLE
Add support for band structure titles

### DIFF
--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -86,6 +86,7 @@ def bandplot(
     dpi=400,
     plt=None,
     fonts=None,
+    title=None,
 ):
     """Plot electronic band structure diagrams from vasprun.xml files.
 
@@ -439,6 +440,7 @@ def bandplot(
             style=style,
             no_base_style=no_base_style,
             spin=spin,
+            title=title,
         )
     else:
         plt = plotter.get_plot(
@@ -459,6 +461,7 @@ def bandplot(
             style=style,
             no_base_style=no_base_style,
             spin=spin,
+            title=title,
         )
 
     if save_files:
@@ -849,6 +852,7 @@ def _get_parser():
         "--dpi", type=int, default=400, help="pixel density for image file"
     )
     parser.add_argument("--font", default=None, help="font to use")
+    parser.add_argument("--title", default=None, help="plot title")
     return parser
 
 
@@ -918,6 +922,7 @@ def main():
         image_format=args.image_format,
         dpi=args.dpi,
         fonts=args.font,
+        title=args.title,
     )
 
 

--- a/sumo/plotting/bs_plotter.py
+++ b/sumo/plotting/bs_plotter.py
@@ -129,6 +129,7 @@ class SBSPlotter(BSPlotter):
         fonts=None,
         style=None,
         no_base_style=False,
+        title=None,
     ):
         """Get a :obj:`matplotlib.pyplot` object of the band structure.
 
@@ -315,6 +316,7 @@ class SBSPlotter(BSPlotter):
             dos_label=dos_label,
             aspect=aspect,
             spin=spin,
+            title=title,
         )
         return plt
 
@@ -352,6 +354,7 @@ class SBSPlotter(BSPlotter):
         style=None,
         no_base_style=False,
         spin=None,
+        title=None,
     ):
         """Get a :obj:`matplotlib.pyplot` of the projected band structure.
 
@@ -686,6 +689,7 @@ class SBSPlotter(BSPlotter):
             plot_dos_legend=plot_dos_legend,
             aspect=aspect,
             spin=spin,
+            title=title,
         )
         return plt
 
@@ -707,6 +711,7 @@ class SBSPlotter(BSPlotter):
         plot_dos_legend=True,
         aspect=None,
         spin=None,
+        title=None,
     ):
         """Tidy the band structure & add the density of states if required."""
         if zero_line:
@@ -729,6 +734,9 @@ class SBSPlotter(BSPlotter):
                 ax.scatter(cbm[0], cbm[1], color="C2", marker="o")
             for vbm in data["vbm"]:
                 ax.scatter(vbm[0], vbm[1], color="C3", marker="o")
+
+        if title:
+            fig.suptitle(title)
 
         if dos_plotter:
             ax = fig.axes[1]

--- a/sumo/plotting/sumo_base.mplstyle
+++ b/sumo/plotting/sumo_base.mplstyle
@@ -1,5 +1,6 @@
 figure.figsize : 3.2, 3.2
 figure.dpi: 400
+figure.titlesize: 14
 
 axes.prop_cycle: cycler('color', ['f0a3ff', '0075dc', '993f00', '4c005c', '426600', 'ff0010', '9dcc00', 'c20088', '003380', 'ffa405', 'ffff00', 'ff5005', '5ef1f2', '740aff', '990000', '00998f', '005c31', '2bce48', 'ffcc99', '94ffb5', '8f7c00', '6fa8bb', '808080'])
 


### PR DESCRIPTION
Hi Sumo devs,

I'm a physics PhD student at UC Berkeley/Berkeley Lab working with Dr. Sinéad Griffin. Sumo is one of my favorite tools and I use it quite heavily, so I would love to contribute.

This very simple PR adds a "title" feature to band plots,  including the new `--title` flag of `sumo-bandplot` and `title` argument of `SBSPlotter.get_plot` and `SBSPlotter.get_projected_plot`. I've found this extremely helpful when, for example, looking at the changes in the electronic structure as you distort or displace atoms-- it's quite helpful for making high quality GIFs for presentations.

Example:
![image](https://github.com/SMTG-UCL/sumo/assets/11034116/b7cf399e-b881-44a6-b2bc-de6ffc695b05)

Example GIF showing the effect of phonons of different amplitudes on Sr3PbO:
![mode1 3](https://github.com/SMTG-UCL/sumo/assets/11034116/6cc97fce-ae82-4f3b-8fae-756e1e1ef4f3)

I have not implemented titles for the other types of plots (DOS, optics, phonons), but it's quite easy to do and I'll see if I can get around to it. I'm not new to developing Python packages (or scientific software more broadly), but I've always worked solo, so please let me know if you have any feedback or guidelines!