### PR TITLE
Fix failing tests and migrate to importlib

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,24 +7,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: setup.py
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install numpy
-        pip install -e .[docs]
+          python -m pip install --upgrade pip
+          python -m pip install numpy
+          python -m pip install -e '.[docs]'
 
     - name: Build
       run: sphinx-build docs/src docs_build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,30 +9,23 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9']
     name: Python ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.py
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy
+          python -m pip install -e '.[tests]'
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install numpy
-
-        pip install -e .
-        pip install -e .[tests]
-
-    - name: Test
-      run: pytest
+      - name: Test
+        run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Python ${{ matrix.python-version }}
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "seekpath",
         "castepxbin<1.0",
         "colormath",
+        "importlib-resources',
     ],
     extras_require={
         "docs": ["sphinx", "sphinx-argparse"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     keywords="chemistry pymatgen dft vasp dos band",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.8",
     install_requires=[
         "spglib",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "seekpath",
         "castepxbin<1.0",
         "colormath",
-        "importlib-resources',
+        "importlib-resources",
     ],
     extras_require={
         "docs": ["sphinx", "sphinx-argparse"],

--- a/sumo/cli/bandplot.py
+++ b/sumo/cli/bandplot.py
@@ -13,9 +13,14 @@ import os
 import sys
 import warnings
 
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 import matplotlib as mpl
-from pkg_resources import Requirement, resource_filename
-from pymatgen.electronic_structure.bandstructure import get_reconstructed_band_structure
+from pymatgen.electronic_structure.bandstructure import (
+    get_reconstructed_band_structure,
+)
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.vasp.outputs import BSVasprun
 
@@ -339,6 +344,7 @@ def bandplot(
 
     # currently not supported as it is a pain to make subplots within subplots,
     # although need to check this is still the case
+    # FIXME: is this necessary if mode can only be "rgb" and "stacked"?
     if "split" in mode and dos_file:
         logging.error(
             "ERROR: Plotting split projected band structure with DOS"
@@ -387,7 +393,9 @@ def bandplot(
                 else:
                     logging.info(f"Found PDOS file {pdos_file}")
             else:
-                logging.info(f"Cell file {cell_file} does not exist, cannot plot PDOS.")
+                logging.info(
+                    f"Cell file {cell_file} does not exist, cannot plot PDOS."
+                )
 
             dos, pdos = read_castep_dos(
                 dos_file,
@@ -609,7 +617,8 @@ def _get_parser():
         "-c",
         "--code",
         default="vasp",
-        help="Electronic structure code (default: vasp)." '"questaal" also supported.',
+        help="Electronic structure code (default: vasp)."
+        '"questaal" also supported.',
     )
     parser.add_argument(
         "-p", "--prefix", metavar="P", help="prefix for the files generated"
@@ -750,7 +759,10 @@ def _get_parser():
         "--orbitals",
         type=_el_orb,
         metavar="O",
-        help=("orbitals to split into lm-decomposed " 'contributions (e.g. "Ru.d")'),
+        help=(
+            "orbitals to split into lm-decomposed "
+            'contributions (e.g. "Ru.d")'
+        ),
     )
     parser.add_argument(
         "--atoms",
@@ -814,7 +826,9 @@ def _get_parser():
     parser.add_argument(
         "--height", type=float, default=None, help="height of the graph"
     )
-    parser.add_argument("--width", type=float, default=None, help="width of the graph")
+    parser.add_argument(
+        "--width", type=float, default=None, help="width of the graph"
+    )
     parser.add_argument(
         "--ymin", type=float, default=-6.0, help="minimum energy on the y-axis"
     )
@@ -865,8 +879,8 @@ def main():
     logging.getLogger("").addHandler(console)
 
     if args.config is None:
-        config_path = resource_filename(
-            Requirement.parse("sumo"), "sumo/plotting/orbital_colours.conf"
+        config_path = os.path.join(
+            ilr_files("sumo.plotting"), "orbital_colours.conf"
         )
     else:
         config_path = args.config
@@ -874,7 +888,9 @@ def main():
     colours.read(os.path.abspath(config_path))
 
     warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
-    warnings.filterwarnings("ignore", category=UnicodeWarning, module="matplotlib")
+    warnings.filterwarnings(
+        "ignore", category=UnicodeWarning, module="matplotlib"
+    )
     warnings.filterwarnings("ignore", category=UserWarning, module="pymatgen")
 
     bandplot(

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -18,7 +18,10 @@ from glob import glob
 
 import matplotlib as mpl
 import numpy as np
-from pkg_resources import Requirement, resource_filename
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 
 mpl.use("Agg")
 
@@ -205,7 +208,6 @@ def dosplot(
         )
 
     elif code.lower() == "castep":
-
         if filename:
             bands_file = filename
         else:
@@ -261,7 +263,13 @@ def dosplot(
         else:
             pdos_candidates = glob("dos.*")
             for candidate in pdos_candidates:
-                if candidate.split(".")[-1] in ("pdf", "png", "svg", "jpg", "jpeg"):
+                if candidate.split(".")[-1] in (
+                    "pdf",
+                    "png",
+                    "svg",
+                    "jpg",
+                    "jpeg",
+                ):
                     continue
                 elif candidate.split(".")[-1].lower() in ("gz", "z", "bz2"):
                     pdos_file = candidate
@@ -422,14 +430,20 @@ def _get_parser():
     )
 
     parser.add_argument(
-        "-f", "--filename", help="vasprun.xml file to plot", default=None, metavar="F"
+        "-f",
+        "--filename",
+        help="vasprun.xml file to plot",
+        default=None,
+        metavar="F",
     )
     parser.add_argument(
         "-c",
         "--code",
         default="vasp",
         metavar="C",
-        help=('Input file format: "vasp" (vasprun.xml) or ' '"questaal" (opt.ext)'),
+        help=(
+            'Input file format: "vasp" (vasprun.xml) or ' '"questaal" (opt.ext)'
+        ),
     )
     parser.add_argument(
         "-p", "--prefix", metavar="P", help="prefix for the files generated"
@@ -449,7 +463,10 @@ def _get_parser():
         "--orbitals",
         type=_el_orb,
         metavar="O",
-        help=("orbitals to split into lm-decomposed " 'contributions (e.g. "Ru.d")'),
+        help=(
+            "orbitals to split into lm-decomposed "
+            'contributions (e.g. "Ru.d")'
+        ),
     )
     parser.add_argument(
         "-a",
@@ -500,7 +517,10 @@ def _get_parser():
         ),
     )
     parser.add_argument(
-        "--no-legend", action="store_false", dest="legend", help="hide the plot legend"
+        "--no-legend",
+        action="store_false",
+        dest="legend",
+        help="hide the plot legend",
     )
     parser.add_argument(
         "--legend-frame",
@@ -540,7 +560,9 @@ def _get_parser():
     parser.add_argument(
         "--height", type=float, default=None, help="height of the graph"
     )
-    parser.add_argument("--width", type=float, default=None, help="width of the graph")
+    parser.add_argument(
+        "--width", type=float, default=None, help="width of the graph"
+    )
     parser.add_argument(
         "--xmin", type=float, default=-6.0, help="minimum energy on the x-axis"
     )
@@ -570,7 +592,10 @@ def _get_parser():
         help="x-axis (i.e. energy) label/units",
     )
     parser.add_argument(
-        "--ylabel", type=str, default="DOS", help="y-axis (i.e. DOS) label/units"
+        "--ylabel",
+        type=str,
+        default="DOS",
+        help="y-axis (i.e. DOS) label/units",
     )
     parser.add_argument(
         "--yscale", type=float, default=1, help="scaling factor for the y-axis"
@@ -609,8 +634,8 @@ def main():
     logging.getLogger("").addHandler(console)
 
     if args.config is None:
-        config_path = resource_filename(
-            Requirement.parse("sumo"), "sumo/plotting/orbital_colours.conf"
+        config_path = os.path.join(
+            ilr_files("sumo.plotting"), "orbital_colours.conf"
         )
     else:
         config_path = args.config
@@ -618,7 +643,9 @@ def main():
     colours.read(os.path.abspath(config_path))
 
     warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
-    warnings.filterwarnings("ignore", category=UnicodeWarning, module="matplotlib")
+    warnings.filterwarnings(
+        "ignore", category=UnicodeWarning, module="matplotlib"
+    )
     warnings.filterwarnings("ignore", category=UserWarning, module="pymatgen")
 
     if args.zero_energy is not None:

--- a/sumo/plotting/__init__.py
+++ b/sumo/plotting/__init__.py
@@ -5,20 +5,29 @@
 Subpackage providing helper functions for generating publication ready plots.
 """
 from functools import wraps
+import os
 
 import matplotlib.pyplot
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.collections import LineCollection
-from pkg_resources import resource_filename
+
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 
 colour_cache = {}
 
-sumo_base_style = resource_filename("sumo.plotting", "sumo_base.mplstyle")
-sumo_dos_style = resource_filename("sumo.plotting", "sumo_dos.mplstyle")
-sumo_bs_style = resource_filename("sumo.plotting", "sumo_bs.mplstyle")
-sumo_phonon_style = resource_filename("sumo.plotting", "sumo_phonon.mplstyle")
-sumo_optics_style = resource_filename("sumo.plotting", "sumo_optics.mplstyle")
+sumo_base_style = os.path.join(ilr_files("sumo.plotting"), "sumo_base.mplstyle")
+sumo_dos_style = os.path.join(ilr_files("sumo.plotting"), "sumo_dos.mplstyle")
+sumo_bs_style = os.path.join(ilr_files("sumo.plotting"), "sumo_bs.mplstyle")
+sumo_phonon_style = os.path.join(
+    ilr_files("sumo.plotting"), "sumo_phonon.mplstyle"
+)
+sumo_optics_style = os.path.join(
+    ilr_files("sumo.plotting"), "sumo_optics.mplstyle"
+)
 
 
 def styled_plot(*style_sheets):
@@ -38,8 +47,9 @@ def styled_plot(*style_sheets):
 
     def decorator(get_plot):
         @wraps(get_plot)
-        def wrapper(*args, fonts=None, style=None, no_base_style=False, **kwargs):
-
+        def wrapper(
+            *args, fonts=None, style=None, no_base_style=False, **kwargs
+        ):
             if no_base_style:
                 list_style = []
             else:
@@ -52,7 +62,9 @@ def styled_plot(*style_sheets):
                     list_style += [style]
 
             if fonts is not None:
-                list_style += [{"font.family": "sans-serif", "font.sans-serif": fonts}]
+                list_style += [
+                    {"font.family": "sans-serif", "font.sans-serif": fonts}
+                ]
 
             matplotlib.pyplot.style.use(list_style)
             return get_plot(*args, **kwargs)
@@ -188,14 +200,14 @@ def colorline(
     Args:
         x (list): x-axis data.
         y (list): y-axis data (can be multidimensional array).
-        weights (list): The weights of the color1, color2, and color3 channels. Given
-            as an array with the shape (n, 3), where n is the same length as the x and
-            y data.
+        weights (list): The weights of the color1, color2, and color3 channels.
+            Given as an array with the shape (n, 3), where n is the same length
+            as the x and y data.
         color1 (str): A color specified in any way supported by matplotlib.
         color2 (str): A color specified in any way supported by matplotlib.
         color3 (str): A color specified in any way supported by matplotlib.
-        colorspace (str): The colorspace in which to perform the interpolation. The
-            allowed values are rgb, hsv, lab, luvlc, lablch, and xyz.
+        colorspace (str): The colorspace in which to perform the interpolation.
+            The allowed values are rgb, hsv, lab, luvlc, lablch, and xyz.
         linestyles (:obj:`str`, optional): Linestyle for plot. Options are
             ``"solid"`` or ``"dotted"``.
     """
@@ -219,7 +231,11 @@ def colorline(
             colours.extend(c.tolist())
 
     lc = LineCollection(
-        seg, colors=colours, rasterized=True, linewidth=linewidth, linestyles=linestyles
+        seg,
+        colors=colours,
+        rasterized=True,
+        linewidth=linewidth,
+        linestyles=linestyles,
     )
     return lc
 
@@ -232,10 +248,11 @@ def get_interpolated_colors(color1, color2, color3, weights, colorspace="lab"):
         color1 (str): A color specified in any way supported by matplotlib.
         color2 (str): A color specified in any way supported by matplotlib.
         color3 (str): A color specified in any way supported by matplotlib.
-        weights (list): A list of weights with the shape (n, 3). Where the 3 values of
-            the last axis give the amount of color1, color2, and color3.
-        colorspace (str): The colorspace in which to perform the interpolation. The
-            allowed values are rgb, hsv, lab, luvlc, lablch, and xyz.
+        weights (list): A list of weights with the shape (n, 3).
+            Where the 3 values of the last axis give the amount of
+            color1, color2, and color3.
+        colorspace (str): The colorspace in which to perform the interpolation.
+            The allowed values are rgb, hsv, lab, luvlc, lablch, and xyz.
 
     Returns:
         A list of colors, specified in the rgb format as a (n, 3) array.
@@ -260,7 +277,9 @@ def get_interpolated_colors(color1, color2, color3, weights, colorspace="lab"):
         "xyz": XYZColor,
     }
     if colorspace not in list(colorspace_mapping.keys()):
-        raise ValueError(f"colorspace must be one of {colorspace_mapping.keys()}")
+        raise ValueError(
+            f"colorspace must be one of {colorspace_mapping.keys()}"
+        )
 
     colorspace = colorspace_mapping[colorspace]
 
@@ -271,13 +290,19 @@ def get_interpolated_colors(color1, color2, color3, weights, colorspace="lab"):
 
     # now convert to the colorspace basis for interpolation
     basis1 = np.array(
-        convert_color(color1_rgb, colorspace, target_illuminant="d50").get_value_tuple()
+        convert_color(
+            color1_rgb, colorspace, target_illuminant="d50"
+        ).get_value_tuple()
     )
     basis2 = np.array(
-        convert_color(color2_rgb, colorspace, target_illuminant="d50").get_value_tuple()
+        convert_color(
+            color2_rgb, colorspace, target_illuminant="d50"
+        ).get_value_tuple()
     )
     basis3 = np.array(
-        convert_color(color3_rgb, colorspace, target_illuminant="d50").get_value_tuple()
+        convert_color(
+            color3_rgb, colorspace, target_illuminant="d50"
+        ).get_value_tuple()
     )
 
     # ensure weights is a numpy array
@@ -292,11 +317,12 @@ def get_interpolated_colors(color1, color2, color3, weights, colorspace="lab"):
 
     # convert colors to RGB
     rgb_colors = [
-        convert_color(colorspace(*c), sRGBColor).get_value_tuple() for c in colors
+        convert_color(colorspace(*c), sRGBColor).get_value_tuple()
+        for c in colors
     ]
 
-    # ensure all rgb values are less than 1 (sometimes issues in interpolation gives
-    # values slightly over 1)
+    # ensure all rgb values are less than 1 (sometimes issues in interpolation
+    # gives values slightly over 1)
     return np.minimum(rgb_colors, 1)
 
 

--- a/sumo/symmetry/brad_crack_kpath.py
+++ b/sumo/symmetry/brad_crack_kpath.py
@@ -6,9 +6,14 @@ Module containing class for generating Bradley and Cracknell k-point paths.
 """
 
 from json import load as load_json
+import os
 
 import numpy as np
-import pkg_resources
+
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 
 from sumo.symmetry import Kpath
 
@@ -61,7 +66,9 @@ class BradCrackKpath(Kpath):
             spg_symbol = self.spg_symbol
             lattice_type = self.lattice_type
 
-        bravais = self._get_bravais_lattice(spg_symbol, lattice_type, a, b, c, unique)
+        bravais = self._get_bravais_lattice(
+            spg_symbol, lattice_type, a, b, c, unique
+        )
         self._kpath = self._get_bradcrack_data(bravais)
 
     @staticmethod
@@ -78,7 +85,7 @@ class BradCrackKpath(Kpath):
                'path': [['\Gamma', 'X', ..., 'P'], ['H', 'N', ...]]}
 
         """
-        json_file = pkg_resources.resource_filename(__name__, "bradcrack.json")
+        json_file = os.path.join(ilr_files("sumo.symmetry"), "bradcrack.json")
         with open(json_file) as f:
             bradcrack_data = load_json(f)
             return bradcrack_data[bravais]

--- a/tests/tests_electronic_structure/test_optics.py
+++ b/tests/tests_electronic_structure/test_optics.py
@@ -7,19 +7,22 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 from pymatgen.io.vasp import Vasprun
 
-from sumo.electronic_structure.optics import calculate_dielectric_properties, kkr
+from sumo.electronic_structure.optics import (
+    calculate_dielectric_properties,
+    kkr,
+)
 
 
 class AbsorptionTestCase(unittest.TestCase):
     def setUp(self):
         diel_path = os.path.join(
-            files(__name__), "..", "data", "Ge", "ge_diel.json"
+            files("tests"), "data", "Ge", "ge_diel.json"
         )
         with open(diel_path) as f:
             self.ge_diel = json.load(f)
 
         absorption_path = os.path.join(
-            files(__name__), "..", "data", "Ge", "ge_alpha.json"
+            files("tests"), "data", "Ge", "ge_alpha.json"
         )
         with open(absorption_path) as f:
             self.ge_abs = json.load(f)
@@ -29,18 +32,20 @@ class AbsorptionTestCase(unittest.TestCase):
             self.ge_diel,
             {"absorption"},
         )
-        self.assertIsNone(assert_almost_equal(properties["absorption"], self.ge_abs))
+        self.assertIsNone(
+            assert_almost_equal(properties["absorption"], self.ge_abs)
+        )
 
 
 class KramersKronigTestCase(unittest.TestCase):
     def setUp(self):
         ge_vasprun_path = os.path.join(
-            files(__name__), "..", "data", "Ge", "vasprun.xml.gz"
+            files("tests"), "data", "Ge", "vasprun.xml.gz"
         )
         self.ge_vasprun = Vasprun(ge_vasprun_path)
 
         self.ge_text_file = ge_vasprun_path = os.path.join(
-            files(__name__), "..", "data", "Ge", "optics.txt"
+            files("tests"), "data", "Ge", "optics.txt"
         )
 
     def test_kkr(self):

--- a/tests/tests_electronic_structure/test_optics.py
+++ b/tests/tests_electronic_structure/test_optics.py
@@ -1,10 +1,10 @@
 import json
 import unittest
-from os.path import join as path_join
+import os
 
+from importlib_resources import files
 import numpy as np
 from numpy.testing import assert_almost_equal
-from pkg_resources import resource_filename
 from pymatgen.io.vasp import Vasprun
 
 from sumo.electronic_structure.optics import calculate_dielectric_properties, kkr
@@ -12,14 +12,14 @@ from sumo.electronic_structure.optics import calculate_dielectric_properties, kk
 
 class AbsorptionTestCase(unittest.TestCase):
     def setUp(self):
-        diel_path = resource_filename(
-            __name__, path_join("..", "data", "Ge", "ge_diel.json")
+        diel_path = os.path.join(
+            files(__name__), "..", "data", "Ge", "ge_diel.json"
         )
         with open(diel_path) as f:
             self.ge_diel = json.load(f)
 
-        absorption_path = resource_filename(
-            __name__, path_join("..", "data", "Ge", "ge_alpha.json")
+        absorption_path = os.path.join(
+            files(__name__), "..", "data", "Ge", "ge_alpha.json"
         )
         with open(absorption_path) as f:
             self.ge_abs = json.load(f)
@@ -34,13 +34,13 @@ class AbsorptionTestCase(unittest.TestCase):
 
 class KramersKronigTestCase(unittest.TestCase):
     def setUp(self):
-        ge_vasprun_path = resource_filename(
-            __name__, path_join("..", "data", "Ge", "vasprun.xml.gz")
+        ge_vasprun_path = os.path.join(
+            files(__name__), "..", "data", "Ge", "vasprun.xml.gz"
         )
         self.ge_vasprun = Vasprun(ge_vasprun_path)
 
-        self.ge_text_file = resource_filename(
-            __name__, path_join("..", "data", "Ge", "optics.txt")
+        self.ge_text_file = ge_vasprun_path = os.path.join(
+            files(__name__), "..", "data", "Ge", "optics.txt"
         )
 
     def test_kkr(self):

--- a/tests/tests_electronic_structure/test_optics.py
+++ b/tests/tests_electronic_structure/test_optics.py
@@ -2,7 +2,10 @@ import json
 import unittest
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 import numpy as np
 from numpy.testing import assert_almost_equal
 from pymatgen.io.vasp import Vasprun
@@ -16,13 +19,13 @@ from sumo.electronic_structure.optics import (
 class AbsorptionTestCase(unittest.TestCase):
     def setUp(self):
         diel_path = os.path.join(
-            files("tests"), "data", "Ge", "ge_diel.json"
+            ilr_files("tests"), "data", "Ge", "ge_diel.json"
         )
         with open(diel_path) as f:
             self.ge_diel = json.load(f)
 
         absorption_path = os.path.join(
-            files("tests"), "data", "Ge", "ge_alpha.json"
+            ilr_files("tests"), "data", "Ge", "ge_alpha.json"
         )
         with open(absorption_path) as f:
             self.ge_abs = json.load(f)
@@ -40,12 +43,12 @@ class AbsorptionTestCase(unittest.TestCase):
 class KramersKronigTestCase(unittest.TestCase):
     def setUp(self):
         ge_vasprun_path = os.path.join(
-            files("tests"), "data", "Ge", "vasprun.xml.gz"
+            ilr_files("tests"), "data", "Ge", "vasprun.xml.gz"
         )
         self.ge_vasprun = Vasprun(ge_vasprun_path)
 
         self.ge_text_file = ge_vasprun_path = os.path.join(
-            files("tests"), "data", "Ge", "optics.txt"
+            ilr_files("tests"), "data", "Ge", "optics.txt"
         )
 
     def test_kkr(self):

--- a/tests/tests_io/test_castep.py
+++ b/tests/tests_io/test_castep.py
@@ -2,7 +2,10 @@ import json
 import unittest
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 from monty.io import gzip
 from monty.json import MontyDecoder
 from numpy.testing import assert_array_almost_equal
@@ -24,19 +27,19 @@ _ry_to_ev = 13.605693009
 class CastepCellTestCase(unittest.TestCase):
     def setUp(self):
         self.si_cell = os.path.join(
-            files("tests"), "data", "Si", "Si2.cell"
+            ilr_files("tests"), "data", "Si", "Si2.cell"
         )
         self.si_cell_alt = os.path.join(
-            files("tests"), "data", "Si", "Si2-alt.cell"
+            ilr_files("tests"), "data", "Si", "Si2-alt.cell"
         )
         self.zns_band_cell = os.path.join(
-            files("tests"), "data", "ZnS", "zns.cell"
+            ilr_files("tests"), "data", "ZnS", "zns.cell"
         )
         self.zns_singlepoint_cell = os.path.join(
-            files("tests"), "data", "ZnS", "zns-sp.cell"
+            ilr_files("tests"), "data", "ZnS", "zns-sp.cell"
         )
         si_structure_file = os.path.join(
-            files("tests"), "data", "Si", "Si8.json"
+            ilr_files("tests"), "data", "Si", "Si8.json"
         )
         self.si_structure = Structure.from_file(si_structure_file)
 
@@ -103,7 +106,7 @@ class CastepDosNiOTestCase(unittest.TestCase):
         }
         for key, value in nio_files.items():
             nio_files[key] = os.path.join(
-                files("tests"), "data", "NiO", value
+                ilr_files("tests"), "data", "NiO", value
             )
 
         self.read_dos_kwargs = nio_files
@@ -112,7 +115,7 @@ class CastepDosNiOTestCase(unittest.TestCase):
         self.ref_data = {}
 
         for key, value in json_files.items():
-            filename = os.path.join(files("tests"), "data", "NiO", value)
+            filename = os.path.join(ilr_files("tests"), "data", "NiO", value)
 
             with gzip.open(filename) as f:
                 self.ref_data[key] = json.load(f, cls=MontyDecoder)
@@ -153,16 +156,16 @@ class CastepDosNiOTestCase(unittest.TestCase):
 class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
     def setUp(self):
         self.si_bands = os.path.join(
-            files("tests"), "data", "Si", "Si2.bands"
+            ilr_files("tests"), "data", "Si", "Si2.bands"
         )
         self.si_cell = os.path.join(
-            files("tests"), "data", "Si", "Si2.cell"
+            ilr_files("tests"), "data", "Si", "Si2.cell"
         )
         self.si_cell_alt = os.path.join(
-            files("tests"), "data", "Si", "Si2-alt.cell"
+            ilr_files("tests"), "data", "Si", "Si2-alt.cell"
         )
         self.si_header_ref = os.path.join(
-            files("tests"), "data", "Si", "Si2.bands_header.json"
+            ilr_files("tests"), "data", "Si", "Si2.bands_header.json"
         )
 
         self.ref_labels = {
@@ -210,7 +213,7 @@ class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
 class CastepBandStructureTestCaseNickel(unittest.TestCase):
     def setUp(self):
         self.ni_cell = os.path.join(
-            files("tests"), "data", "Ni", "ni-band.cell"
+            ilr_files("tests"), "data", "Ni", "ni-band.cell"
         )
 
         self.ref_labels = {
@@ -230,14 +233,14 @@ class CastepBandStructureTestCaseNickel(unittest.TestCase):
 class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
     def setUp(self):
         self.fe_bands = os.path.join(
-            files("tests"), "data", "Fe", "Fe.bands"
+            ilr_files("tests"), "data", "Fe", "Fe.bands"
         )
 
         self.fe_cell = os.path.join(
-            files("tests"), "data", "Fe", "Fe.cell"
+            ilr_files("tests"), "data", "Fe", "Fe.cell"
         )
         self.fe_header_ref = os.path.join(
-            files("tests"), "data", "Fe", "Fe.bands_header.json"
+            ilr_files("tests"), "data", "Fe", "Fe.bands_header.json"
         )
 
     def test_castep_bands_read_header(self):
@@ -250,7 +253,7 @@ class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
 class BandStructureTestCasePathBreak(unittest.TestCase):
     def setUp(self):
         self.pt_cell = os.path.join(
-            files("tests"), "data", "Pt", "Pt.cell"
+            ilr_files("tests"), "data", "Pt", "Pt.cell"
         )
         self.ref_labels = {
             r"\Gamma": (0.0, 0.0, 0.0),
@@ -273,13 +276,13 @@ class BandStructureTestCasePathBreak(unittest.TestCase):
 class CastepPhononTestCaseZincblende(unittest.TestCase):
     def setUp(self):
         self.zns_phonon = os.path.join(
-            files("tests"), "data", "ZnS", "zns.phonon"
+            ilr_files("tests"), "data", "ZnS", "zns.phonon"
         )
         self.zns_cell = os.path.join(
-            files("tests"), "data", "ZnS", "zns.cell"
+            ilr_files("tests"), "data", "ZnS", "zns.cell"
         )
         self.zns_phonon_ref = os.path.join(
-            files("tests"), "data", "ZnS", "zns_phonon.json"
+            ilr_files("tests"), "data", "ZnS", "zns_phonon.json"
         )
 
     def test_castep_phonon_read_bands(self):

--- a/tests/tests_io/test_castep.py
+++ b/tests/tests_io/test_castep.py
@@ -273,18 +273,14 @@ class BandStructureTestCasePathBreak(unittest.TestCase):
 class CastepPhononTestCaseZincblende(unittest.TestCase):
     def setUp(self):
         self.zns_phonon = os.path.join(
-            files("tests"), "data", "Zns", "zns.phonon"
+            files("tests"), "data", "ZnS", "zns.phonon"
         )
         self.zns_cell = os.path.join(
-            files("tests"), "data", "Zns", "zns.cell"
+            files("tests"), "data", "ZnS", "zns.cell"
         )
         self.zns_phonon_ref = os.path.join(
-            files("tests"), "data", "Zns", "zns_phonon.json"
+            files("tests"), "data", "ZnS", "zns_phonon.json"
         )
-        import logging
-        logging.warning(f"zns_phonon_ref: {self.zns_phonon_ref}")
-        logging.warning(f"zns_phonon: {self.zns_phonon}")
-        logging.warning(f"zns_cell: {self.zns_cell}")
 
     def test_castep_phonon_read_bands(self):
         castep_phonon = CastepPhonon.from_file(self.zns_phonon)

--- a/tests/tests_io/test_castep.py
+++ b/tests/tests_io/test_castep.py
@@ -1,11 +1,11 @@
 import json
 import unittest
-from os.path import join as path_join
+import os
 
+from importlib_resources import files
 from monty.io import gzip
 from monty.json import MontyDecoder
 from numpy.testing import assert_array_almost_equal
-from pkg_resources import resource_filename
 from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.core import Spin
 
@@ -23,20 +23,20 @@ _ry_to_ev = 13.605693009
 
 class CastepCellTestCase(unittest.TestCase):
     def setUp(self):
-        self.si_cell = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2.cell")
+        self.si_cell = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2.cell"
         )
-        self.si_cell_alt = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2-alt.cell")
+        self.si_cell_alt = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2-alt.cell"
         )
-        self.zns_band_cell = resource_filename(
-            __name__, path_join("..", "data", "ZnS", "zns.cell")
+        self.zns_band_cell = os.path.join(
+            files(__name__), "..", "data", "ZnS", "zns.cell"
         )
-        self.zns_singlepoint_cell = resource_filename(
-            __name__, path_join("..", "data", "ZnS", "zns-sp.cell")
+        self.zns_singlepoint_cell = os.path.join(
+            files(__name__), "..", "data", "ZnS", "zns-sp.cell"
         )
-        si_structure_file = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si8.json")
+        si_structure_file = os.path.join(
+            files(__name__), "..", "data", "Si", "Si8.json"
         )
         self.si_structure = Structure.from_file(si_structure_file)
 
@@ -51,7 +51,8 @@ class CastepCellTestCase(unittest.TestCase):
     def test_castep_cell_from_singlepoint_file(self):
         cc = CastepCell.from_file(self.zns_singlepoint_cell)
         self.assertEqual(
-            set(cc.blocks.keys()), {"lattice_cart", "positions_abs", "species_pot"}
+            set(cc.blocks.keys()),
+            {"lattice_cart", "positions_abs", "species_pot"},
         )
         self.assertEqual(
             {k: v.value for k, v in cc.tags.items()},
@@ -88,7 +89,8 @@ class CastepCellTestCase(unittest.TestCase):
             cell.blocks["positions_frac"].values[0], ["Si", "0.0", "0.0", "0.0"]
         )
         self.assertEqual(
-            cell.blocks["positions_frac"].values[7], ["Si", "0.75", "0.75", "0.25"]
+            cell.blocks["positions_frac"].values[7],
+            ["Si", "0.75", "0.75", "0.25"],
         )
 
 
@@ -100,18 +102,17 @@ class CastepDosNiOTestCase(unittest.TestCase):
             "cell_file": "NiO.cell",
         }
         for key, value in nio_files.items():
-            nio_files[key] = resource_filename(
-                __name__, path_join("..", "data", "NiO", value)
+            nio_files[key] = os.path.join(
+                files(__name__), "..", "data", "NiO", value
             )
+
         self.read_dos_kwargs = nio_files
 
         json_files = {"dos": "dos-pmg.json.gz", "pdos": "pdos-pmg.json.gz"}
         self.ref_data = {}
 
         for key, value in json_files.items():
-            filename = resource_filename(
-                __name__, path_join("..", "data", "NiO", value)
-            )
+            filename = os.path.join(files(__name__), "..", "data", "NiO", value)
 
             with gzip.open(filename) as f:
                 self.ref_data[key] = json.load(f, cls=MontyDecoder)
@@ -151,17 +152,17 @@ class CastepDosNiOTestCase(unittest.TestCase):
 
 class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
     def setUp(self):
-        self.si_bands = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2.bands")
+        self.si_bands = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2.bands"
         )
-        self.si_cell = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2.cell")
+        self.si_cell = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2.cell"
         )
-        self.si_cell_alt = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2-alt.cell")
+        self.si_cell_alt = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2-alt.cell"
         )
-        self.si_header_ref = resource_filename(
-            __name__, path_join("..", "data", "Si", "Si2.bands_header.json")
+        self.si_header_ref = os.path.join(
+            files(__name__), "..", "data", "Si", "Si2.bands_header.json"
         )
 
         self.ref_labels = {
@@ -181,12 +182,16 @@ class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
     def test_castep_bands_read_eigenvalues(self):
         with open(self.si_header_ref) as f:
             ref_header = json.load(f)
-        kpoints, weights, eigenvals = read_bands_eigenvalues(self.si_bands, ref_header)
+        kpoints, weights, eigenvals = read_bands_eigenvalues(
+            self.si_bands, ref_header
+        )
 
         for i, k in enumerate([0.5, 0.36111111, 0.63888889]):
             self.assertAlmostEqual(kpoints[4][i], k)
 
-        self.assertAlmostEqual(eigenvals[Spin.up][2, 4], 0.09500443 * _ry_to_ev * 2)
+        self.assertAlmostEqual(
+            eigenvals[Spin.up][2, 4], 0.09500443 * _ry_to_ev * 2
+        )
 
         for weight in weights:
             self.assertAlmostEqual(weight, 0.02272727)
@@ -204,8 +209,8 @@ class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
 
 class CastepBandStructureTestCaseNickel(unittest.TestCase):
     def setUp(self):
-        self.ni_cell = resource_filename(
-            __name__, path_join("..", "data", "Ni", "ni-band.cell")
+        self.ni_cell = os.path.join(
+            files(__name__), "..", "data", "Ni", "ni-band.cell"
         )
 
         self.ref_labels = {
@@ -224,14 +229,15 @@ class CastepBandStructureTestCaseNickel(unittest.TestCase):
 
 class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
     def setUp(self):
-        self.fe_bands = resource_filename(
-            __name__, path_join("..", "data", "Fe", "Fe.bands")
+        self.fe_bands = os.path.join(
+            files(__name__), "..", "data", "Fe", "Fe.bands"
         )
-        self.fe_cell = resource_filename(
-            __name__, path_join("..", "data", "Fe", "Fe.cell")
+
+        self.fe_cell = os.path.join(
+            files(__name__), "..", "data", "Fe", "Fe.cell"
         )
-        self.fe_header_ref = resource_filename(
-            __name__, path_join("..", "data", "Fe", "Fe.bands_header.json")
+        self.fe_header_ref = os.path.join(
+            files(__name__), "..", "data", "Fe", "Fe.bands_header.json"
         )
 
     def test_castep_bands_read_header(self):
@@ -243,8 +249,8 @@ class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
 
 class BandStructureTestCasePathBreak(unittest.TestCase):
     def setUp(self):
-        self.pt_cell = resource_filename(
-            __name__, path_join("..", "data", "Pt", "Pt.cell")
+        self.pt_cell = os.path.join(
+            files(__name__), "..", "data", "Pt", "Pt.cell"
         )
         self.ref_labels = {
             r"\Gamma": (0.0, 0.0, 0.0),
@@ -252,7 +258,7 @@ class BandStructureTestCasePathBreak(unittest.TestCase):
             "U": (0.625, 0.25, 0.625),
             "K": (0.375, 0.375, 0.75),
             "L": (0.5, 0.5, 0.5),
-            "W": (0.5, 0.25, 0.75)
+            "W": (0.5, 0.25, 0.75),
         }
 
     def test_castep_parse_break_in_k_path(self):
@@ -266,15 +272,14 @@ class BandStructureTestCasePathBreak(unittest.TestCase):
 #   sumo-phonon-bandplot -f zns.phonon --units cm-1 --to-json zns_phonon.json
 class CastepPhononTestCaseZincblende(unittest.TestCase):
     def setUp(self):
-        self.zns_phonon = resource_filename(
-            __name__, path_join("..", "data", "ZnS", "zns.phonon")
+        self.zns_phonon = os.path.join(
+            files(__name__), "..", "data", "Zns", "zns.phonon"
         )
-
-        self.zns_cell = resource_filename(
-            __name__, path_join("..", "data", "ZnS", "zns.cell")
+        self.zns_cell = os.path.join(
+            files(__name__), "..", "data", "Zns", "zns.cell"
         )
-        self.zns_phonon_ref = resource_filename(
-            __name__, path_join("..", "data", "ZnS", "zns_phonon.json")
+        self.zns_phonon_ref = os.path.join(
+            files(__name__), "..", "data", "Zns", "zns_phonon.json"
         )
 
     def test_castep_phonon_read_bands(self):
@@ -296,7 +301,9 @@ class CastepPhononTestCaseZincblende(unittest.TestCase):
         )
         assert_array_almost_equal(bs_dict["qpoints"], ref_dict["qpoints"])
         self.assertEqual(bs_dict["labels_dict"], ref_dict["labels_dict"])
-        self.assertEqual(bs_dict["structure"]["sites"], ref_dict["structure"]["sites"])
+        self.assertEqual(
+            bs_dict["structure"]["sites"], ref_dict["structure"]["sites"]
+        )
         assert_array_almost_equal(
             bs_dict["structure"]["lattice"]["matrix"],
             ref_dict["structure"]["lattice"]["matrix"],

--- a/tests/tests_io/test_castep.py
+++ b/tests/tests_io/test_castep.py
@@ -24,19 +24,19 @@ _ry_to_ev = 13.605693009
 class CastepCellTestCase(unittest.TestCase):
     def setUp(self):
         self.si_cell = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2.cell"
+            files("tests"), "data", "Si", "Si2.cell"
         )
         self.si_cell_alt = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2-alt.cell"
+            files("tests"), "data", "Si", "Si2-alt.cell"
         )
         self.zns_band_cell = os.path.join(
-            files(__name__), "..", "data", "ZnS", "zns.cell"
+            files("tests"), "data", "ZnS", "zns.cell"
         )
         self.zns_singlepoint_cell = os.path.join(
-            files(__name__), "..", "data", "ZnS", "zns-sp.cell"
+            files("tests"), "data", "ZnS", "zns-sp.cell"
         )
         si_structure_file = os.path.join(
-            files(__name__), "..", "data", "Si", "Si8.json"
+            files("tests"), "data", "Si", "Si8.json"
         )
         self.si_structure = Structure.from_file(si_structure_file)
 
@@ -103,7 +103,7 @@ class CastepDosNiOTestCase(unittest.TestCase):
         }
         for key, value in nio_files.items():
             nio_files[key] = os.path.join(
-                files(__name__), "..", "data", "NiO", value
+                files("tests"), "data", "NiO", value
             )
 
         self.read_dos_kwargs = nio_files
@@ -112,7 +112,7 @@ class CastepDosNiOTestCase(unittest.TestCase):
         self.ref_data = {}
 
         for key, value in json_files.items():
-            filename = os.path.join(files(__name__), "..", "data", "NiO", value)
+            filename = os.path.join(files("tests"), "data", "NiO", value)
 
             with gzip.open(filename) as f:
                 self.ref_data[key] = json.load(f, cls=MontyDecoder)
@@ -153,16 +153,16 @@ class CastepDosNiOTestCase(unittest.TestCase):
 class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
     def setUp(self):
         self.si_bands = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2.bands"
+            files("tests"), "data", "Si", "Si2.bands"
         )
         self.si_cell = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2.cell"
+            files("tests"), "data", "Si", "Si2.cell"
         )
         self.si_cell_alt = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2-alt.cell"
+            files("tests"), "data", "Si", "Si2-alt.cell"
         )
         self.si_header_ref = os.path.join(
-            files(__name__), "..", "data", "Si", "Si2.bands_header.json"
+            files("tests"), "data", "Si", "Si2.bands_header.json"
         )
 
         self.ref_labels = {
@@ -210,7 +210,7 @@ class CastepBandStructureTestCaseNoSpin(unittest.TestCase):
 class CastepBandStructureTestCaseNickel(unittest.TestCase):
     def setUp(self):
         self.ni_cell = os.path.join(
-            files(__name__), "..", "data", "Ni", "ni-band.cell"
+            files("tests"), "data", "Ni", "ni-band.cell"
         )
 
         self.ref_labels = {
@@ -230,14 +230,14 @@ class CastepBandStructureTestCaseNickel(unittest.TestCase):
 class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
     def setUp(self):
         self.fe_bands = os.path.join(
-            files(__name__), "..", "data", "Fe", "Fe.bands"
+            files("tests"), "data", "Fe", "Fe.bands"
         )
 
         self.fe_cell = os.path.join(
-            files(__name__), "..", "data", "Fe", "Fe.cell"
+            files("tests"), "data", "Fe", "Fe.cell"
         )
         self.fe_header_ref = os.path.join(
-            files(__name__), "..", "data", "Fe", "Fe.bands_header.json"
+            files("tests"), "data", "Fe", "Fe.bands_header.json"
         )
 
     def test_castep_bands_read_header(self):
@@ -250,7 +250,7 @@ class CastepBandStructureTestCaseWithSpin(unittest.TestCase):
 class BandStructureTestCasePathBreak(unittest.TestCase):
     def setUp(self):
         self.pt_cell = os.path.join(
-            files(__name__), "..", "data", "Pt", "Pt.cell"
+            files("tests"), "data", "Pt", "Pt.cell"
         )
         self.ref_labels = {
             r"\Gamma": (0.0, 0.0, 0.0),
@@ -273,14 +273,18 @@ class BandStructureTestCasePathBreak(unittest.TestCase):
 class CastepPhononTestCaseZincblende(unittest.TestCase):
     def setUp(self):
         self.zns_phonon = os.path.join(
-            files(__name__), "..", "data", "Zns", "zns.phonon"
+            files("tests"), "data", "Zns", "zns.phonon"
         )
         self.zns_cell = os.path.join(
-            files(__name__), "..", "data", "Zns", "zns.cell"
+            files("tests"), "data", "Zns", "zns.cell"
         )
         self.zns_phonon_ref = os.path.join(
-            files(__name__), "..", "data", "Zns", "zns_phonon.json"
+            files("tests"), "data", "Zns", "zns_phonon.json"
         )
+        import logging
+        logging.warning(f"zns_phonon_ref: {self.zns_phonon_ref}")
+        logging.warning(f"zns_phonon: {self.zns_phonon}")
+        logging.warning(f"zns_cell: {self.zns_cell}")
 
     def test_castep_phonon_read_bands(self):
         castep_phonon = CastepPhonon.from_file(self.zns_phonon)

--- a/tests/tests_io/test_questaal.py
+++ b/tests/tests_io/test_questaal.py
@@ -1,7 +1,10 @@
 import unittest
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 import numpy as np
 from pymatgen.core.lattice import Lattice
 
@@ -11,7 +14,7 @@ from sumo.io.questaal import QuestaalInit, dielectric_from_file
 class QuestaalOpticsTestCase(unittest.TestCase):
     def setUp(self):
         self.bse_path = os.path.join(
-            files("tests"), "data", "SnO2", "eps_BSE.out"
+            ilr_files("tests"), "data", "SnO2", "eps_BSE.out"
         )
 
     def test_optics_from_bethesalpeter(self):
@@ -172,7 +175,7 @@ class QuestaalInitTestCase(unittest.TestCase):
             QuestaalInit(lattice, site)
 
     def test_init_from_file(self):
-        zno_path = os.path.join(files("tests"), "data", "ZnO")
+        zno_path = os.path.join(ilr_files("tests"), "data", "ZnO")
 
         init1 = QuestaalInit.from_file(
             os.path.join(zno_path, "init.zno_nosym"), preprocessor=False

--- a/tests/tests_io/test_questaal.py
+++ b/tests/tests_io/test_questaal.py
@@ -1,8 +1,8 @@
 import unittest
-from os.path import join as path_join
+import os
 
+from importlib_resources import files
 import numpy as np
-from pkg_resources import resource_filename
 from pymatgen.core.lattice import Lattice
 
 from sumo.io.questaal import QuestaalInit, dielectric_from_file
@@ -10,8 +10,8 @@ from sumo.io.questaal import QuestaalInit, dielectric_from_file
 
 class QuestaalOpticsTestCase(unittest.TestCase):
     def setUp(self):
-        self.bse_path = resource_filename(
-            __name__, path_join("..", "data", "SnO2", "eps_BSE.out")
+        self.bse_path = os.path.join(
+            files(__name__), "..", "data", "SnO2", "eps_BSE.out"
         )
 
     def test_optics_from_bethesalpeter(self):
@@ -25,7 +25,11 @@ class QuestaalOpticsTestCase(unittest.TestCase):
 class QuestaalInitTestCase(unittest.TestCase):
     def setUp(self):
         self.ref_lat = np.array(
-            [[1.59205, -2.757511, 0.0], [1.59205, 2.757511, 0.0], [0.0, 0.0, 5.1551]]
+            [
+                [1.59205, -2.757511, 0.0],
+                [1.59205, 2.757511, 0.0],
+                [0.0, 0.0, 5.1551],
+            ]
         )
 
         self.ref_pmg_lat = Lattice(self.ref_lat)
@@ -33,7 +37,13 @@ class QuestaalInitTestCase(unittest.TestCase):
     def test_init_from_python(self):
         """Check Questaal input object"""
         # spcgroup example
-        lattice = {"SPCGRP": 186, "A": 3.18409958, "C": 5.1551, "UNITS": "A", "ALAT": 1}
+        lattice = {
+            "SPCGRP": 186,
+            "A": 3.18409958,
+            "C": 5.1551,
+            "UNITS": "A",
+            "ALAT": 1,
+        }
         site = [
             {"ATOM": "Zn", "X": (0.6666670, 0.3333330, 0.5000000)},
             {"ATOM": "O", "X": (0.6666670, 0.3333330, 0.8803100)},
@@ -46,7 +56,13 @@ class QuestaalInitTestCase(unittest.TestCase):
 
         # Check ALAT ok
         init_sym_alat = QuestaalInit(
-            {"SPCGRP": 186, "A": 0.318409958, "C": 0.51551, "UNITS": "A", "ALAT": 10},
+            {
+                "SPCGRP": 186,
+                "A": 0.318409958,
+                "C": 0.51551,
+                "UNITS": "A",
+                "ALAT": 10,
+            },
             site,
         )
         self.assertEqual(init_sym.structure, init_sym_alat.structure)
@@ -74,7 +90,9 @@ class QuestaalInitTestCase(unittest.TestCase):
         self.assertFalse(init_plat.cartesian)
 
         init_plat_alat = QuestaalInit(lattice, site)
-        init_plat_alat.lattice["PLAT"] = np.array(init_plat_alat.lattice["PLAT"]) * 0.1
+        init_plat_alat.lattice["PLAT"] = (
+            np.array(init_plat_alat.lattice["PLAT"]) * 0.1
+        )
         init_plat_alat.lattice["ALAT"] = 10
         self.assertEqual(init_plat.structure, init_plat_alat.structure)
 
@@ -122,14 +140,22 @@ class QuestaalInitTestCase(unittest.TestCase):
         bohr_init_noconvert = QuestaalInit(
             bohr_lattice, bohr_cart_sites, ignore_units=True
         )
-        self.assertAlmostEqual(bohr_init_noconvert.structure.lattice.abc[2], 9.74172715)
+        self.assertAlmostEqual(
+            bohr_init_noconvert.structure.lattice.abc[2], 9.74172715
+        )
         self.assertAlmostEqual(
             bohr_init_noconvert.structure.distance_matrix[0, -1], 3.66441077
         )
 
     def test_init_coordinate_safety(self):
         """Check illegal Questaal input caught"""
-        lattice = {"SPCGRP": 186, "A": 3.18409958, "C": 5.1551, "UNITS": "A", "ALAT": 1}
+        lattice = {
+            "SPCGRP": 186,
+            "A": 3.18409958,
+            "C": 5.1551,
+            "UNITS": "A",
+            "ALAT": 1,
+        }
         site = [
             {"ATOM": "Zn", "X": (0.6666670, 0.3333330, 0.5000000)},
             {"ATOM": "O", "POS": (0.6666670, 0.3333330, 0.8803100)},
@@ -146,12 +172,13 @@ class QuestaalInitTestCase(unittest.TestCase):
             QuestaalInit(lattice, site)
 
     def test_init_from_file(self):
-        zno_path = resource_filename(__name__, path_join("..", "data", "ZnO"))
+        zno_path = os.path.join(files(__name__), "..", "data", "ZnO")
+
         init1 = QuestaalInit.from_file(
-            path_join(zno_path, "init.zno_nosym"), preprocessor=False
+            os.path.join(zno_path, "init.zno_nosym"), preprocessor=False
         )
         init2 = QuestaalInit.from_file(
-            path_join(zno_path, "init.zno_sym"), preprocessor=False
+            os.path.join(zno_path, "init.zno_sym"), preprocessor=False
         )
         nosym_structure = init1.structure
         sym_structure = init2.structure
@@ -178,7 +205,8 @@ class QuestaalInitTestCase(unittest.TestCase):
         self.assertLess(
             (
                 abs(
-                    np.array(self.ref_pmg_lat.abc) - np.array(sym_structure.lattice.abc)
+                    np.array(self.ref_pmg_lat.abc)
+                    - np.array(sym_structure.lattice.abc)
                 )
             ).max(),
             1e-5,

--- a/tests/tests_io/test_questaal.py
+++ b/tests/tests_io/test_questaal.py
@@ -11,7 +11,7 @@ from sumo.io.questaal import QuestaalInit, dielectric_from_file
 class QuestaalOpticsTestCase(unittest.TestCase):
     def setUp(self):
         self.bse_path = os.path.join(
-            files(__name__), "..", "data", "SnO2", "eps_BSE.out"
+            files("tests"), "data", "SnO2", "eps_BSE.out"
         )
 
     def test_optics_from_bethesalpeter(self):
@@ -172,7 +172,7 @@ class QuestaalInitTestCase(unittest.TestCase):
             QuestaalInit(lattice, site)
 
     def test_init_from_file(self):
-        zno_path = os.path.join(files(__name__), "..", "data", "ZnO")
+        zno_path = os.path.join(files("tests"), "data", "ZnO")
 
         init1 = QuestaalInit.from_file(
             os.path.join(zno_path, "init.zno_nosym"), preprocessor=False

--- a/tests/tests_phonon/test_phonopy.py
+++ b/tests/tests_phonon/test_phonopy.py
@@ -1,9 +1,9 @@
 import unittest
-from os.path import join as path_join
+import os
 
+from importlib_resources import files
 import numpy as np
 from phonopy import Phonopy
-from pkg_resources import resource_filename
 from pymatgen.io.vasp.inputs import Poscar
 
 import sumo.phonon.phonopy
@@ -11,11 +11,11 @@ import sumo.phonon.phonopy
 
 class PhonopyTestCase(unittest.TestCase):
     def setUp(self):
-        self.phonon_data = resource_filename(
-            __name__, path_join("..", "data", "RbSnI6", "phonopy", "FORCE_SETS")
+        self.phonon_data = os.path.join(
+            files(__name__), "..", "data", "RbSnI6", "phonopy", "FORCE_SETS"
         )
-        poscar_path = resource_filename(
-            __name__, path_join("..", "data", "RbSnI6", "phonopy", "POSCAR")
+        poscar_path = os.path.join(
+            files(__name__), "..", "data", "RbSnI6", "phonopy", "POSCAR"
         )
         phonon_poscar = Poscar.from_file(poscar_path)
         self.phonon_structure = phonon_poscar.structure

--- a/tests/tests_phonon/test_phonopy.py
+++ b/tests/tests_phonon/test_phonopy.py
@@ -1,7 +1,10 @@
 import unittest
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 import numpy as np
 from phonopy import Phonopy
 from pymatgen.io.vasp.inputs import Poscar
@@ -12,10 +15,10 @@ import sumo.phonon.phonopy
 class PhonopyTestCase(unittest.TestCase):
     def setUp(self):
         self.phonon_data = os.path.join(
-            files("tests"), "data", "RbSnI6", "phonopy", "FORCE_SETS"
+            ilr_files("tests"), "data", "RbSnI6", "phonopy", "FORCE_SETS"
         )
         poscar_path = os.path.join(
-            files("tests"), "data", "RbSnI6", "phonopy", "POSCAR"
+            ilr_files("tests"), "data", "RbSnI6", "phonopy", "POSCAR"
         )
         phonon_poscar = Poscar.from_file(poscar_path)
         self.phonon_structure = phonon_poscar.structure

--- a/tests/tests_phonon/test_phonopy.py
+++ b/tests/tests_phonon/test_phonopy.py
@@ -12,10 +12,10 @@ import sumo.phonon.phonopy
 class PhonopyTestCase(unittest.TestCase):
     def setUp(self):
         self.phonon_data = os.path.join(
-            files(__name__), "..", "data", "RbSnI6", "phonopy", "FORCE_SETS"
+            files("tests"), "data", "RbSnI6", "phonopy", "FORCE_SETS"
         )
         poscar_path = os.path.join(
-            files(__name__), "..", "data", "RbSnI6", "phonopy", "POSCAR"
+            files("tests"), "data", "RbSnI6", "phonopy", "POSCAR"
         )
         phonon_poscar = Poscar.from_file(poscar_path)
         self.phonon_structure = phonon_poscar.structure

--- a/tests/tests_plotting/test_dos_plotter.py
+++ b/tests/tests_plotting/test_dos_plotter.py
@@ -5,8 +5,10 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 import matplotlib.pyplot
 
 import sumo.plotting
@@ -17,7 +19,7 @@ from sumo.plotting.dos_plotter import get_cached_colour
 class GetColourTestCase(unittest.TestCase):
     def setUp(self):
         config_path = os.path.join(
-            files("sumo.plotting"), "orbital_colours.conf"
+            ilr_files("sumo.plotting"), "orbital_colours.conf"
         )
 
         self.config = configparser.ConfigParser()

--- a/tests/tests_plotting/test_dos_plotter.py
+++ b/tests/tests_plotting/test_dos_plotter.py
@@ -5,9 +5,8 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-# Can use importlib.resources in python>=3.9
-from importlib_resources import files
 
+from importlib_resources import files
 import matplotlib.pyplot
 
 import sumo.plotting

--- a/tests/tests_plotting/test_dos_plotter.py
+++ b/tests/tests_plotting/test_dos_plotter.py
@@ -1,11 +1,12 @@
 import unittest
-import importlib.resources
 import os
 
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+# Can use importlib.resources in python>=3.9
+from importlib_resources import files
 
 import matplotlib.pyplot
 
@@ -17,7 +18,7 @@ from sumo.plotting.dos_plotter import get_cached_colour
 class GetColourTestCase(unittest.TestCase):
     def setUp(self):
         config_path = os.path.join(
-            importlib.resources.files("sumo.plotting"), "orbital_colours.conf"
+            files("sumo.plotting"), "orbital_colours.conf"
         )
 
         self.config = configparser.ConfigParser()

--- a/tests/tests_plotting/test_dos_plotter.py
+++ b/tests/tests_plotting/test_dos_plotter.py
@@ -1,7 +1,6 @@
 import unittest
-from os.path import abspath
-
-from pkg_resources import Requirement, resource_filename
+import importlib.resources
+import os
 
 try:
     import configparser
@@ -17,13 +16,12 @@ from sumo.plotting.dos_plotter import get_cached_colour
 
 class GetColourTestCase(unittest.TestCase):
     def setUp(self):
-        # Open default CLI colours config
-        config_path = resource_filename(
-            Requirement.parse("sumo"), "sumo/plotting/orbital_colours.conf"
+        config_path = os.path.join(
+            importlib.resources.files("sumo.plotting"), "orbital_colours.conf"
         )
 
         self.config = configparser.ConfigParser()
-        self.config.read(abspath(config_path))
+        self.config.read(os.path.abspath(config_path))
 
     def test_get_colour_cache(self):
         """Check colour caching"""

--- a/tests/tests_symmetry/test_bradcrack_kpath.py
+++ b/tests/tests_symmetry/test_bradcrack_kpath.py
@@ -2,7 +2,10 @@ import unittest
 import warnings
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.brad_crack_kpath import BradCrackKpath
@@ -12,7 +15,7 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 class BradCrackKpathTestCase(unittest.TestCase):
     def setUp(self):
         poscar = os.path.join(
-            files("tests"), "data", "Cs2SnI6", "dos", "vasprun.xml.gz"
+            ilr_files("tests"), "data", "Cs2SnI6", "dos", "vasprun.xml.gz"
         )
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")

--- a/tests/tests_symmetry/test_bradcrack_kpath.py
+++ b/tests/tests_symmetry/test_bradcrack_kpath.py
@@ -12,7 +12,7 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 class BradCrackKpathTestCase(unittest.TestCase):
     def setUp(self):
         poscar = os.path.join(
-            files(__name__), "..", "data", "Cs2SnI6", "dos", "vasprun.xml.gz"
+            files("tests"), "data", "Cs2SnI6", "dos", "vasprun.xml.gz"
         )
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")

--- a/tests/tests_symmetry/test_bradcrack_kpath.py
+++ b/tests/tests_symmetry/test_bradcrack_kpath.py
@@ -1,8 +1,8 @@
 import unittest
 import warnings
-from os.path import join as path_join
+import os
 
-import pkg_resources
+from importlib_resources import files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.brad_crack_kpath import BradCrackKpath
@@ -11,8 +11,8 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 
 class BradCrackKpathTestCase(unittest.TestCase):
     def setUp(self):
-        poscar = pkg_resources.resource_filename(
-            __name__, path_join("..", "data", "Cs2SnI6", "dos", "vasprun.xml.gz")
+        poscar = os.path.join(
+            files(__name__), "..", "data", "Cs2SnI6", "dos", "vasprun.xml.gz"
         )
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
@@ -27,7 +27,9 @@ class BradCrackKpathTestCase(unittest.TestCase):
             "triclinic",
         )
         self.assertEqual(
-            BradCrackKpath._get_bravais_lattice("Fd-3m", "cubic", 5.66, 5.66, 5.66, 0),
+            BradCrackKpath._get_bravais_lattice(
+                "Fd-3m", "cubic", 5.66, 5.66, 5.66, 0
+            ),
             "cubic_f",
         )
 

--- a/tests/tests_symmetry/test_custom_kpath.py
+++ b/tests/tests_symmetry/test_custom_kpath.py
@@ -1,8 +1,8 @@
 import unittest
 import warnings
-from os.path import join as path_join
+import os
 
-import pkg_resources
+from importlib_resources import files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.custom_kpath import CustomKpath
@@ -10,9 +10,7 @@ from sumo.symmetry.custom_kpath import CustomKpath
 
 class CustomKpathTestCase(unittest.TestCase):
     def setUp(self):
-        poscar = pkg_resources.resource_filename(
-            __name__, path_join("..", "data", "Ge", "POSCAR")
-        )
+        poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
             self.structure = Structure.from_file(poscar)

--- a/tests/tests_symmetry/test_custom_kpath.py
+++ b/tests/tests_symmetry/test_custom_kpath.py
@@ -10,7 +10,7 @@ from sumo.symmetry.custom_kpath import CustomKpath
 
 class CustomKpathTestCase(unittest.TestCase):
     def setUp(self):
-        poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
+        poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
             self.structure = Structure.from_file(poscar)
@@ -27,7 +27,8 @@ class CustomKpathTestCase(unittest.TestCase):
         ]
 
         self.assertEqual(
-            CustomKpath._auto_kpath_labels(kpts_flat), [["(1)", "(2)", "(3)", "(4)"]]
+            CustomKpath._auto_kpath_labels(kpts_flat),
+            [["(1)", "(2)", "(3)", "(4)"]],
         )
         self.assertEqual(
             CustomKpath._auto_kpath_labels(kpts_multisegment),

--- a/tests/tests_symmetry/test_custom_kpath.py
+++ b/tests/tests_symmetry/test_custom_kpath.py
@@ -2,7 +2,10 @@ import unittest
 import warnings
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.custom_kpath import CustomKpath
@@ -10,7 +13,7 @@ from sumo.symmetry.custom_kpath import CustomKpath
 
 class CustomKpathTestCase(unittest.TestCase):
     def setUp(self):
-        poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
+        poscar = os.path.join(ilr_files("tests"), "data", "Ge", "POSCAR")
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
             self.structure = Structure.from_file(poscar)

--- a/tests/tests_symmetry/test_pymatgen_kpath.py
+++ b/tests/tests_symmetry/test_pymatgen_kpath.py
@@ -12,9 +12,9 @@ from sumo.symmetry.pymatgen_kpath import PymatgenKpath
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
         zno_poscar = os.path.join(
-            files(__name__), "..", "data", "ZnO", "POSCAR"
+            files("tests"), "data", "ZnO", "POSCAR"
         )
-        hgs_poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
+        hgs_poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
 
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")

--- a/tests/tests_symmetry/test_pymatgen_kpath.py
+++ b/tests/tests_symmetry/test_pymatgen_kpath.py
@@ -1,8 +1,8 @@
 import unittest
 import warnings
-from os.path import join as path_join
+import os
 
-import pkg_resources
+from importlib_resources import files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.brad_crack_kpath import BradCrackKpath
@@ -11,13 +11,10 @@ from sumo.symmetry.pymatgen_kpath import PymatgenKpath
 
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
-        zno_poscar = pkg_resources.resource_filename(
-            __name__, path_join("..", "data", "ZnO", "POSCAR")
+        zno_poscar = os.path.join(
+            files(__name__), "..", "data", "ZnO", "POSCAR"
         )
-
-        hgs_poscar = pkg_resources.resource_filename(
-            __name__, path_join("..", "data", "Ge", "POSCAR")
-        )
+        hgs_poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
 
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
@@ -44,4 +41,6 @@ class SeekpathKpathTestCase(unittest.TestCase):
         # Bradcrack kpoints should be a subset of pymatgen kpoints
         for label, position in kpath_bradcrack.kpoints.items():
             self.assertIn(label, kpath_pymatgen.kpoints)
-            self.assertEqual(list(position), list(kpath_pymatgen.kpoints[label]))
+            self.assertEqual(
+                list(position), list(kpath_pymatgen.kpoints[label])
+            )

--- a/tests/tests_symmetry/test_pymatgen_kpath.py
+++ b/tests/tests_symmetry/test_pymatgen_kpath.py
@@ -2,7 +2,10 @@ import unittest
 import warnings
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.brad_crack_kpath import BradCrackKpath
@@ -12,9 +15,9 @@ from sumo.symmetry.pymatgen_kpath import PymatgenKpath
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
         zno_poscar = os.path.join(
-            files("tests"), "data", "ZnO", "POSCAR"
+            ilr_files("tests"), "data", "ZnO", "POSCAR"
         )
-        hgs_poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
+        hgs_poscar = os.path.join(ilr_files("tests"), "data", "Ge", "POSCAR")
 
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")

--- a/tests/tests_symmetry/test_seekpath_kpath.py
+++ b/tests/tests_symmetry/test_seekpath_kpath.py
@@ -2,7 +2,10 @@ import unittest
 import warnings
 import os
 
-from importlib_resources import files
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.seekpath_kpath import SeekpathKpath
@@ -10,7 +13,7 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
-        ge_poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
+        ge_poscar = os.path.join(ilr_files("tests"), "data", "Ge", "POSCAR")
 
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")

--- a/tests/tests_symmetry/test_seekpath_kpath.py
+++ b/tests/tests_symmetry/test_seekpath_kpath.py
@@ -1,8 +1,8 @@
 import unittest
 import warnings
-from os.path import join as path_join
+import os
 
-import pkg_resources
+from importlib_resources import files
 from pymatgen.core.structure import Structure
 
 from sumo.symmetry.seekpath_kpath import SeekpathKpath
@@ -10,9 +10,8 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
-        ge_poscar = pkg_resources.resource_filename(
-            __name__, path_join("..", "data", "Ge", "POSCAR")
-        )
+        ge_poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
+
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")
             self.ge_structure = Structure.from_file(ge_poscar)

--- a/tests/tests_symmetry/test_seekpath_kpath.py
+++ b/tests/tests_symmetry/test_seekpath_kpath.py
@@ -10,7 +10,7 @@ from sumo.symmetry.seekpath_kpath import SeekpathKpath
 
 class SeekpathKpathTestCase(unittest.TestCase):
     def setUp(self):
-        ge_poscar = os.path.join(files(__name__), "..", "data", "Ge", "POSCAR")
+        ge_poscar = os.path.join(files("tests"), "data", "Ge", "POSCAR")
 
         with warnings.catch_warnings():  # Not interested in Pymatgen warnings
             warnings.simplefilter("ignore")


### PR DESCRIPTION
Hi again, 

This PR moves sumo from using `pkg_resources` to `importlib.resources`, which fixes the failing tests. Note that `pkg_resources` is now [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and the devs recommend migrating to `importlib.resources` or the `importlib-resources` backport for older versions of python.

**Changelog**:
* Replace `pkg_resources` with `importlib.resources` for python 3.9+ and the `importlib_resources` backport for python 3.8. This fixes the issue of failing tests.
* Turn `tests` into its own package for easier use with `importlib.resources.files`, and add proper exclusion to `setup.py`
* Update both the tests and docs workflows to use more up-to-date actions, thus eliminating the deprecation warnings and simplifying the caching action.
* A little bit of linting for PEP8 compliance.