### PR TITLE
Small docstring fix for `sumo-dosplot`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-v2.3.9
-------
+Unreleased
+----------
 
 * Minor docstring updates (@kavanase, https://github.com/SMTG-Bham/sumo/pull/241)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,14 @@ Change Log
 v2.3.9
 ------
 
-* Minor docstring updates (@kavanase, #241)
+* Minor docstring updates (@kavanase, https://github.com/SMTG-Bham/sumo/pull/241)
 
 v2.3.8
 ------
 
 Bugfixes:
 
-- Fixed bug with sumo-phonon-bandplot and recent versions of pymatgen (@utf, #227)
+- Fixed bug with sumo-phonon-bandplot and recent versions of pymatgen (@utf, https://github.com/SMTG-Bham/sumo/pull/227)
 
 v2.3.7
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+v2.3.9
+------
+
+* Minor docstring updates (@kavanase, #241)
+
 v2.3.8
 ------
 

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -537,7 +537,7 @@ def _get_parser():
         type=float,
         default=None,
         dest="zero_energy",
-        help="Plot vertical line at energy zero",
+        help="zero energy reference eigenvalue. Default is Fermi level from VASP."
     )
 
     parser.add_argument(

--- a/sumo/cli/dosplot.py
+++ b/sumo/cli/dosplot.py
@@ -537,7 +537,8 @@ def _get_parser():
         type=float,
         default=None,
         dest="zero_energy",
-        help="zero energy reference eigenvalue. Default is Fermi level from VASP."
+        help="Reference energy: energy will be shifted to place this energy "
+            "at zero. If not specified (and `--no-shift` not used), zero will be set to the VBM."
     )
 
     parser.add_argument(

--- a/sumo/cli/optplot.py
+++ b/sumo/cli/optplot.py
@@ -65,8 +65,8 @@ def optplot(
     Args:
         modes (:obj:`list` or :obj:`tuple`):
             Ordered list of :obj:`str` determining properties to plot.
-            Accepted options are 'absorption' (default), 'eps', 'eps-real',
-            'eps-im', 'n', 'n-real', 'n-im', 'loss' (equivalent to n-im).
+            Accepted options are 'absorption' (default), 'eps_real',
+            'eps_imag', 'n_real', 'n_imag', 'loss' (equivalent to n_imag).
         filenames (:obj:`str` or :obj:`list`, optional): Path to data file.
             For VASP this is a *vasprun.xml* file (can be gzipped); for
             Questaal the *opt.ext* file from *lmf* or *eps_BSE.out* from


### PR DESCRIPTION
Just noticed that the docstring for `zero-energy` in `sumo-dosplot` was incorrect (duplication of `zero-line` which has different behaviour), so just a small update