### PR TITLE
Numpy 2.0 compatibility tweak

### DIFF
--- a/sumo/electronic_structure/optics.py
+++ b/sumo/electronic_structure/optics.py
@@ -256,7 +256,7 @@ def kkr(de, eps_imag, cshift=1e-6):
     eps_imag = np.array(eps_imag)
     nedos = eps_imag.shape[0]
     cshift = complex(0, cshift)
-    w_i = np.arange(0, (nedos - 0.5) * de, de, dtype=np.complex_)
+    w_i = np.arange(0, (nedos - 0.5) * de, de, dtype=np.complex128)
     w_i = np.reshape(w_i, (nedos, 1, 1))
 
     def integration_element(w_r):


### PR DESCRIPTION
Checked the code with `ruff check . --select NPY201` and this was the only required change.

```
~/s/sumo (numpy-fix)> ruff check . --select NPY201                                 (science)
sumo/electronic_structure/optics.py:259:54: NPY201 [*] `np.complex_` will be removed in NumPy 2.0. Use `numpy.complex128` instead.
Found 1 error.
[*] 1 fixable with the `--fix` option.
```