### PR TITLE
Fix SOC DOS parsing for latest `pymatgen`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Update SOC DOS handling for ``pymatgen>=2025`` and add tests
+  (@kavanase, https://github.com/SMTG-Bham/sumo/pull/256)
+
 v2.3.10
 -------
 

--- a/sumo/electronic_structure/dos.py
+++ b/sumo/electronic_structure/dos.py
@@ -125,7 +125,7 @@ def load_dos(
                     site, orbital
                 ).get_smeared_densities(gaussian)
 
-    if vr.parameters["LSORBIT"]:
+    if vr.parameters["LSORBIT"] and Spin.down in dos.densities:
         # pymatgen includes the spin down channel for SOC calculations, even
         # though there is no density here. We remove this channel so the
         # plotting is easier later on.

--- a/sumo/electronic_structure/dos.py
+++ b/sumo/electronic_structure/dos.py
@@ -125,14 +125,14 @@ def load_dos(
                     site, orbital
                 ).get_smeared_densities(gaussian)
 
-    if vr.parameters["LSORBIT"] and Spin.down in dos.densities:
-        # pymatgen includes the spin down channel for SOC calculations, even
-        # though there is no density here. We remove this channel so the
-        # plotting is easier later on.
-        del dos.densities[Spin.down]
+    if vr.parameters["LSORBIT"]:
+        # pymatgen<2025 includes the Spin.down channel for SOC calculations in the 
+        # dos/pdos, even though there is no density here. We remove this channel (if
+        # present) so the plotting is easier later on:
+        dos.densities.pop(Spin.down, None)
         for site in dos.pdos:
             for orbital in dos.pdos[site]:
-                del dos.pdos[site][orbital][Spin.down]
+                dos.pdos[site][orbital].pop(Spin.down, None)
 
     pdos = {}
     if not total_only:

--- a/tests/tests_electronic_structure/test_dos.py
+++ b/tests/tests_electronic_structure/test_dos.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+
+try:
+    from importlib.resources import files as ilr_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as ilr_files
+
+from sumo.electronic_structure.dos import load_dos
+from pymatgen.electronic_structure.core import Spin
+
+
+class DosTestCase(unittest.TestCase):
+    def setUp(self):
+        self.vr_path = os.path.join(ilr_files("tests"), "data", "Cs2SnBr6", "vasprun.xml.gz")
+
+    def test_load_dos(self):
+        dos, pdos = load_dos(self.vr_path)  # previously would fail due to old SOC vr handling
+        self.assertEqual(len(dos.energies), 2000)  # NEDOS
+        self.assertEqual(list(dos.densities.keys()), [Spin.up])  # no Spin down key
+        self.assertEqual(len(dos.densities[Spin.up]), len(dos.energies))  # matching array lengths

--- a/tests/tests_electronic_structure/test_dos.py
+++ b/tests/tests_electronic_structure/test_dos.py
@@ -12,6 +12,7 @@ from pymatgen.electronic_structure.core import Spin
 
 class DosTestCase(unittest.TestCase):
     def setUp(self):
+        # SOC DOS calculation:
         self.vr_path = os.path.join(ilr_files("tests"), "data", "Cs2SnBr6", "vasprun.xml.gz")
 
     def test_load_dos(self):


### PR DESCRIPTION
Since https://github.com/materialsproject/pymatgen/pull/4239, `Spin.down` entries are no longer stored in `pymatgen` DOS objects parsed from SOC calculations (as desired). There was a patch in `sumo` to delete this entry for SOC calculations if present, to make later downstream plotting easier, but this now causes a `KeyError` when used with the latest `pymatgen` due to this entry no longer being present:
```
sumo-dosplot
Traceback (most recent call last):
  File "/home/mmm0650/miniconda3/bin/sumo-dosplot", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/mmm0650/miniconda3/lib/python3.12/site-packages/sumo/cli/dosplot.py", line 646, in main
    dosplot(
  File "/home/mmm0650/miniconda3/lib/python3.12/site-packages/sumo/cli/dosplot.py", line 207, in dosplot
    dos, pdos = load_dos(
                ^^^^^^^^^
  File "/home/mmm0650/miniconda3/lib/python3.12/site-packages/sumo/electronic_structure/dos.py", line 132, in load_dos
    del dos.densities[Spin.down]
        ~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: <Spin.down: -1>
```

This small update fixes the issue.